### PR TITLE
Update emby.css

### DIFF
--- a/src/css/emby.css
+++ b/src/css/emby.css
@@ -1,3 +1,5 @@
+::cue { background-color:transparent; }
+
 @font-face {
     font-family: 'Roboto';
     font-style: normal;


### PR DESCRIPTION
Since the default settings for WebVTT subtitle tracks are white text on black background, and this background is usually useless and often ugly, I propose adding this line to the css to make them white text on transparent background.
